### PR TITLE
ci: bump to Go 1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.16
 
       - name: Setup Node
         uses: actions/setup-node@v2-beta
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.16
 
       - name: Setup Node
         uses: actions/setup-node@v2-beta

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,3 +13,7 @@ linters:
     - goerr113 # allow "dynamic" errors
     - goconst # not all strings should be constants
     - nlreturn # allow returns without blank line before
+    - wrapcheck # don't require error wrapping everywhere
+    - errorlint # don't require %w error verbs
+    - exhaustivestruct # don't require exhaustive structs
+    - paralleltest # don't require t.Parallel() in all tests

--- a/balena_test.go
+++ b/balena_test.go
@@ -105,6 +105,7 @@ func newFixture() (*Client, *http.ServeMux, func()) {
 // BALENA_APP_ID
 // BALENA_DEVICE_UUID.
 func supervisorV2Fixture(t *testing.T) (*SupervisorV2Service, *http.ServeMux) {
+	t.Helper()
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 	client, err := NewSupervisorV2(nil)
@@ -124,6 +125,7 @@ func supervisorV2Fixture(t *testing.T) (*SupervisorV2Service, *http.ServeMux) {
 // BALENA_APP_ID
 // BALENA_DEVICE_UUID.
 func supervisorV1Fixture(t *testing.T) (*SupervisorV1Service, *http.ServeMux) {
+	t.Helper()
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 	client, err := NewSupervisorV1(nil)
@@ -137,6 +139,7 @@ func supervisorV1Fixture(t *testing.T) (*SupervisorV1Service, *http.ServeMux) {
 }
 
 func testMethod(t *testing.T, r *http.Request, expected string) {
+	t.Helper()
 	if expected != r.Method {
 		t.Errorf("Request method = %v, expected %v", r.Method, expected)
 	}

--- a/devicetag_test.go
+++ b/devicetag_test.go
@@ -40,7 +40,7 @@ func TestDeviceTagService_List_ID(t *testing.T) {
 		testMethod(t, r, http.MethodGet)
 		expected := "%24filter=device/id+eq+%27" + strconv.FormatInt(deviceID, 10) + "%27"
 		if r.URL.RawQuery != expected {
-			fmt.Printf("query = %s ; expected %s\n", r.URL.RawQuery, expected)
+			t.Logf("query = %s ; expected %s\n", r.URL.RawQuery, expected)
 			http.Error(w, fmt.Sprintf("query = %s ; expected %s", r.URL.RawQuery, expected), 500)
 			return
 		}

--- a/releasetag_test.go
+++ b/releasetag_test.go
@@ -38,7 +38,7 @@ func TestReleaseTagService_List(t *testing.T) {
 		testMethod(t, r, http.MethodGet)
 		expected := "%24filter=release/id+eq+%27" + strconv.FormatInt(releaseID, 10) + "%27"
 		if r.URL.RawQuery != expected {
-			fmt.Printf("query = %s ; expected = %s\n", r.URL.RawQuery, expected)
+			t.Logf("query = %s ; expected = %s\n", r.URL.RawQuery, expected)
 			http.Error(w, fmt.Sprintf("query = %s ; expected = %s\n", r.URL.RawQuery, expected), 500)
 		}
 		fmt.Fprint(w, jsonResp)
@@ -88,7 +88,7 @@ func TestReleaseTagService_ListByCommit(t *testing.T) {
 		testMethod(t, r, http.MethodGet)
 		expected := "%24filter=release/commit+eq+%27" + releaseCommit + "%27"
 		if r.URL.RawQuery != expected {
-			fmt.Printf("query = %s ; expected = %s\n", r.URL.RawQuery, expected)
+			t.Logf("query = %s ; expected = %s\n", r.URL.RawQuery, expected)
 			http.Error(w, fmt.Sprintf("query = %s ; expected = %s\n", r.URL.RawQuery, expected), 500)
 		}
 		fmt.Fprint(w, jsonResp)
@@ -138,7 +138,7 @@ func TestReleaseTagService_GetWithQuery(t *testing.T) {
 		testMethod(t, r, http.MethodGet)
 		expected := "%24filter=release/commit+eq+%27" + strconv.FormatInt(releaseID, 10) + "%27"
 		if r.URL.RawQuery != expected {
-			fmt.Printf("query = %s ; expected = %s\n", r.URL.RawQuery, expected)
+			t.Logf("query = %s ; expected = %s\n", r.URL.RawQuery, expected)
 			http.Error(w, fmt.Sprintf("query = %s ; expected = %s\n", r.URL.RawQuery, expected), 500)
 		}
 		fmt.Fprint(w, jsonResp)

--- a/tools/golangci-lint/rules.mk
+++ b/tools/golangci-lint/rules.mk
@@ -1,5 +1,5 @@
 golangci_lint_cwd := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-golangci_lint_version := 1.30.0
+golangci_lint_version := 1.37.0
 golangci_lint := $(golangci_lint_cwd)/$(golangci_lint_version)/golangci-lint
 
 ifeq ($(shell uname),Linux)


### PR DESCRIPTION
Including bumping GolangCI-Lint for Go 1.16 language support.
