### PR TITLE
add mac_address to DeviceResponse struct

### DIFF
--- a/device.go
+++ b/device.go
@@ -61,6 +61,7 @@ type DeviceResponse struct {
 	LogsChannel                interface{}   `json:"logs_channel,omitempty"`
 	IsLockedUntil              interface{}   `json:"is_locked_until__date,omitempty"`
 	IsAccessibleBySupportUntil interface{}   `json:"is_accessible_by_support_until__date,omitempty"`
+	MACAddress                 interface{}   `json:"mac_address,omitempty"`
 }
 
 // List returns a list of all devices.


### PR DESCRIPTION
Hi guys, thanks for the work you've done so far on the project! I wanted to be able to grab the mac_address field from the device response payload so I've made a PR.

There are a few other fields not covered like cpu_temp that I didn't add. I don't know if that was intentional but I'd be happy to circle back and add the missing json properties.