### PR TITLE
feat(env): allow update of existing env vars

### DIFF
--- a/balena.go
+++ b/balena.go
@@ -30,14 +30,15 @@ type Client struct {
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
 
 	// Services used for talking to different parts of the Balena API
-	Application   *ApplicationService
-	Device        *DeviceService
-	Release       *ReleaseService
-	ReleaseTag    *ReleaseTagService
-	DeviceEnvVar  *DeviceEnvVarService
-	DeviceServVar *DeviceServVarService
-	DeviceConfVar *DeviceConfVarService
-	DeviceTag     *DeviceTagService
+	Application    *ApplicationService
+	Device         *DeviceService
+	Release        *ReleaseService
+	ReleaseTag     *ReleaseTagService
+	DeviceEnvVar   *DeviceEnvVarService
+	DeviceServVar  *DeviceServVarService
+	DeviceConfVar  *DeviceConfVarService
+	DeviceTag      *DeviceTagService
+	ServiceInstall *ServiceInstallService
 }
 
 type service struct {
@@ -76,6 +77,7 @@ func New(httpClient *http.Client, authToken string) *Client {
 	c.DeviceConfVar = (*DeviceConfVarService)(&c.common)
 	c.DeviceTag = (*DeviceTagService)(&c.common)
 	c.ReleaseTag = (*ReleaseTagService)(&c.common)
+	c.ServiceInstall = (*ServiceInstallService)(&c.common)
 	return c
 }
 

--- a/deviceenvvar_test.go
+++ b/deviceenvvar_test.go
@@ -316,6 +316,27 @@ func TestDeviceEnvVarService_DeleteWithName_UUID_OK(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func TestDeviceEnvVarService_Update(t *testing.T) {
+	// Given
+	uuid := "12345678901234567890"
+	key := "key"
+	client, mux, cleanup := newFixture()
+	defer cleanup()
+	mux.HandleFunc("/"+deviceEnvVarBasePath, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		expected := "%24filter=device/uuid+eq+%27" + uuid + "%27+and+name+eq+%27" + key + "%27"
+		if r.URL.RawQuery != expected {
+			http.Error(w, fmt.Sprintf("query = %s ; expected %s", r.URL.RawQuery, expected), 500)
+			return
+		}
+		_, _ = fmt.Fprint(w, "OK")
+	})
+	// When
+	err := client.DeviceEnvVar.Update(context.Background(), DeviceUUID(uuid), key, "newVal")
+	// Then
+	assert.NilError(t, err)
+}
+
 func TestDeviceEnvVarService_DeleteWithName_NotFound(t *testing.T) {
 	// Given
 	deviceID := int64(123456)

--- a/deviceservvar.go
+++ b/deviceservvar.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"go.einride.tech/balena/odata"
 )
@@ -14,11 +13,19 @@ const deviceServVarBasePath = "v6/device_service_environment_variable"
 type DeviceServVarService service
 
 type DeviceServVarResponse struct {
-	ID        int64        `json:"id,omitempty"`
-	CreatedAt string       `json:"created_at,omitempty"`
-	Device    odata.Object `json:"device,omitempty"`
-	Name      string       `json:"name,omitempty"`
-	Value     string       `json:"value,omitempty"`
+	ID             int64           `json:"id,omitempty"`
+	CreatedAt      string          `json:"created_at,omitempty"`
+	Name           string          `json:"name,omitempty"`
+	Value          string          `json:"value,omitempty"`
+	ServiceInstall ServiceInstalls `json:"service_install,omitempty"`
+}
+
+type DeviceServVarCreateResponse struct {
+	ID             int64        `json:"id,omitempty"`
+	CreatedAt      string       `json:"created_at,omitempty"`
+	Name           string       `json:"name,omitempty"`
+	Value          string       `json:"value,omitempty"`
+	ServiceInstall odata.Object `json:"service_install,omitempty"`
 }
 
 // List lists all environment variables given a specific device ID/UUID.
@@ -27,6 +34,8 @@ func (s *DeviceServVarService) List(ctx context.Context, deviceID IDOrUUID) ([]*
 	if deviceID.isUUID {
 		query = "%24filter=service_install/device/uuid+eq+%27" + deviceID.id + "%27"
 	}
+	//nolint:lll
+	query += "&$expand=service_install($select=id,device,created_at;$expand=installs__service($select=id,service_name,created_at,application))"
 	req, err := s.client.NewRequest(ctx, http.MethodGet, deviceServVarBasePath, query, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create request: %v", err)
@@ -42,41 +51,54 @@ func (s *DeviceServVarService) List(ctx context.Context, deviceID IDOrUUID) ([]*
 	return resp.D, nil
 }
 
-// Create creates an environment variable with name=value given a device ID/UUID.
+// Create creates an environment variable with name=value given a ServiceInstall ID (see ServiceInstallService).
 func (s *DeviceServVarService) Create(
 	ctx context.Context,
-	deviceID IDOrUUID,
+	serviceInstallID int64,
 	name string,
 	value string,
-) (*DeviceServVarResponse, error) {
-	// If UUID, retrieve device ID
-	id := deviceID.id
-	if deviceID.isUUID {
-		resp, err := s.client.Device.Get(ctx, deviceID)
-		if err != nil {
-			return nil, err
-		}
-		id = strconv.FormatInt(resp.ID, 10)
-	}
+) (*DeviceServVarCreateResponse, error) {
 	type request struct {
-		DeviceID string `json:"device"`
-		Name     string `json:"name"`
-		Value    string `json:"value"`
+		ServiceInstallID int64  `json:"service_install"`
+		Name             string `json:"name"`
+		Value            string `json:"value"`
 	}
 	req, err := s.client.NewRequest(ctx, http.MethodPost, deviceServVarBasePath, "", &request{
-		DeviceID: id,
-		Name:     name,
-		Value:    value,
+		ServiceInstallID: serviceInstallID,
+		Name:             name,
+		Value:            value,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to create request: %v", err)
 	}
-	resp := &DeviceServVarResponse{}
+	resp := &DeviceServVarCreateResponse{}
 	err = s.client.Do(req, resp)
 	if err != nil {
 		return nil, fmt.Errorf("unable to perform request: %v", err)
 	}
 	return resp, nil
+}
+
+// Update a variable with the given name from the device with given ID/UUID to a new value.
+// No error is returned if no variable with such name exists.
+func (s *DeviceServVarService) Update(ctx context.Context, deviceID IDOrUUID, name, newValue string) error {
+	query := "%24filter=service_install/device+eq+%27" + deviceID.id + "%27"
+	if deviceID.isUUID {
+		query = "%24filter=service_install/device/uuid+eq+%27" + deviceID.id + "%27"
+	}
+	query = query + "+and+name+eq+%27" + name + "%27"
+	body := struct {
+		Value string `json:"value"`
+	}{Value: newValue}
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, deviceServVarBasePath, query, body)
+	if err != nil {
+		return fmt.Errorf("unable to create request: %v", err)
+	}
+	err = s.client.Do(req, nil)
+	if err != nil {
+		return fmt.Errorf("unable to perform request: %v", err)
+	}
+	return nil
 }
 
 // DeleteWithName deletes a variable with the given name from the device with given ID/UUID.

--- a/deviceservvar_test.go
+++ b/deviceservvar_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
+	"time"
 
 	"go.einride.tech/balena/odata"
 	"gotest.tools/v3/assert"
@@ -18,14 +19,39 @@ func TestDeviceServVarService_List_ID(t *testing.T) {
 	jsonResp := `{
 	"d": [
 		{
+            "service_install": [
+                {
+                    "installs__service": [
+                        {
+                            "id": 1101713,
+							"application": {
+								"__id": 1660000,
+								"__deferred": {
+									"uri": "/resin/application(@id)?@id=1660000"
+								}
+							},
+							"created_at": "2020-06-18T20:26:23.470Z",
+                            "service_name": "vehiclelogger",
+                            "__metadata": {
+                                "uri": "/resin/service(@id)?@id=1101713"
+                            }
+                        }
+                    ],
+                    "id": 7185462,
+            		"created_at": "2021-10-15T08:06:13.353Z",
+                    "device": {
+                        "__id": 1702297,
+                        "__deferred": {
+                            "uri": "/resin/device(@id)?@id=1702297"
+                        }
+                    },
+                    "__metadata": {
+                        "uri": "/resin/service_install(@id)?@id=7185462"
+                    }
+                }
+            ],
 			"id": 183330,
 			"created_at": "2019-09-27T17:54:21.559Z",
-			"device": {
-				"__deferred": {
-					"uri": "/resin/device(1702297)"
-				},
-				"__id": 1702297
-			},
 			"name": "key",
 			"value": "test",
 			"__metadata": {
@@ -39,23 +65,43 @@ func TestDeviceServVarService_List_ID(t *testing.T) {
 	defer cleanup()
 	mux.HandleFunc("/"+deviceServVarBasePath, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		expected := "%24filter=service_install/device+eq+%27123456%27"
+		//nolint:lll
+		expected := "%24filter=service_install/device+eq+%27123456%27&$expand=service_install($select=id,device,created_at;$expand=installs__service($select=id,service_name,created_at,application))"
 		if r.URL.RawQuery != expected {
 			http.Error(w, fmt.Sprintf("query = %s ; expected %s", r.URL.RawQuery, expected), 500)
 			return
 		}
-		fmt.Fprint(w, jsonResp)
+		_, _ = fmt.Fprint(w, jsonResp)
 	})
 	expected := []*DeviceServVarResponse{
 		{
 			ID:        183330,
 			CreatedAt: "2019-09-27T17:54:21.559Z",
-			Device: odata.Object{
-				Deferred: odata.Deferred{URI: "/resin/device(1702297)"},
-				ID:       1702297,
+			Name:      "key",
+			Value:     "test",
+			ServiceInstall: []*ServiceInstallResponse{
+				{
+					InstallsService: []InstallsService{
+						{
+							ID:          1101713,
+							ServiceName: "vehiclelogger",
+							Application: odata.Object{
+								Deferred: odata.Deferred{
+									URI: "/resin/application(@id)?@id=1660000",
+								},
+								ID: 1660000,
+							},
+							CreatedAt: time.Date(2020, 6, 18, 20, 26, 23, 470_000_000, time.UTC),
+						},
+					},
+					ID:        7185462,
+					CreatedAt: time.Date(2021, 10, 15, 8, 6, 13, 353_000_000, time.UTC),
+					Device: odata.Object{
+						Deferred: odata.Deferred{URI: "/resin/device(@id)?@id=1702297"},
+						ID:       1702297,
+					},
+				},
 			},
-			Name:  "key",
-			Value: "test",
 		},
 	}
 	// When
@@ -70,14 +116,39 @@ func TestDeviceServVarService_List_UUID(t *testing.T) {
 	jsonResp := `{
 	"d": [
 		{
+            "service_install": [
+                {
+                    "installs__service": [
+                        {
+                            "id": 1101713,
+							"application": {
+								"__id": 1660000,
+								"__deferred": {
+									"uri": "/resin/application(@id)?@id=1660000"
+								}
+							},
+							"created_at": "2020-06-18T20:26:23.470Z",
+                            "service_name": "vehiclelogger",
+                            "__metadata": {
+                                "uri": "/resin/service(@id)?@id=1101713"
+                            }
+                        }
+                    ],
+                    "id": 7185462,
+            		"created_at": "2021-10-15T08:06:13.353Z",
+                    "device": {
+                        "__id": 1702297,
+                        "__deferred": {
+                            "uri": "/resin/device(@id)?@id=1702297"
+                        }
+                    },
+                    "__metadata": {
+                        "uri": "/resin/service_install(@id)?@id=7185462"
+                    }
+                }
+            ],
 			"id": 183330,
 			"created_at": "2019-09-27T17:54:21.559Z",
-			"device": {
-				"__deferred": {
-					"uri": "/resin/device(1702297)"
-				},
-				"__id": 1702297
-			},
 			"name": "key",
 			"value": "test",
 			"__metadata": {
@@ -91,23 +162,43 @@ func TestDeviceServVarService_List_UUID(t *testing.T) {
 	defer cleanup()
 	mux.HandleFunc("/"+deviceServVarBasePath, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		expected := "%24filter=service_install/device/uuid+eq+%27" + uuid + "%27"
+		//nolint:lll
+		expected := "%24filter=service_install/device/uuid+eq+%27" + uuid + "%27&$expand=service_install($select=id,device,created_at;$expand=installs__service($select=id,service_name,created_at,application))"
 		if r.URL.RawQuery != expected {
 			http.Error(w, fmt.Sprintf("query = %s ; expected %s", r.URL.RawQuery, expected), 500)
 			return
 		}
-		fmt.Fprint(w, jsonResp)
+		_, _ = fmt.Fprint(w, jsonResp)
 	})
 	expected := []*DeviceServVarResponse{
 		{
 			ID:        183330,
 			CreatedAt: "2019-09-27T17:54:21.559Z",
-			Device: odata.Object{
-				Deferred: odata.Deferred{URI: "/resin/device(1702297)"},
-				ID:       1702297,
+			Name:      "key",
+			Value:     "test",
+			ServiceInstall: []*ServiceInstallResponse{
+				{
+					InstallsService: []InstallsService{
+						{
+							ID: 1101713,
+							Application: odata.Object{
+								Deferred: odata.Deferred{
+									URI: "/resin/application(@id)?@id=1660000",
+								},
+								ID: 1660000,
+							},
+							CreatedAt:   time.Date(2020, 6, 18, 20, 26, 23, 470_000_000, time.UTC),
+							ServiceName: "vehiclelogger",
+						},
+					},
+					ID:        7185462,
+					CreatedAt: time.Date(2021, 10, 15, 8, 6, 13, 353_000_000, time.UTC),
+					Device: odata.Object{
+						Deferred: odata.Deferred{URI: "/resin/device(@id)?@id=1702297"},
+						ID:       1702297,
+					},
+				},
 			},
-			Name:  "key",
-			Value: "test",
 		},
 	}
 	// When
@@ -122,51 +213,54 @@ func TestDeviceServVarService_Create_ID(t *testing.T) {
 	jsonResp := `{
 	"id": 183330,
 	"created_at": "2019-09-27T17:54:21.559Z",
-	"device": {
-		"__deferred": {
-			"uri": "/resin/device(1702297)"
-		},
-		"__id": 1702297
-	},
+    "service_install": {
+        "__id": 7185462,
+        "__deferred": {
+            "uri": "/resin/service_install(@id)?@id=7185462"
+        }
+    },
 	"name": "key",
 	"value": "test",
 	"__metadata": {
 		"uri": "/resin/device_service_environment_variable(@id)?@id=183330"
 	}
 }`
-	deviceID := int64(123456)
+	serviceInstallID := int64(7185462)
 	key := "key"
 	value := "value"
 	client, mux, cleanup := newFixture()
 	defer cleanup()
 	type request struct {
-		Device string `json:"device"`
-		Name   string `json:"name"`
-		Value  string `json:"value"`
+		ServiceInstallID int64  `json:"service_install"`
+		Name             string `json:"name"`
+		Value            string `json:"value"`
 	}
+	mux.HandleFunc("/v6/service_install", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"D": [{"id": %d}]}`, serviceInstallID)
+	})
 	mux.HandleFunc("/"+deviceServVarBasePath, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		b, err := ioutil.ReadAll(r.Body)
 		assert.NilError(t, err)
 		req := &request{}
 		assert.NilError(t, json.Unmarshal(b, req))
-		assert.Equal(t, strconv.FormatInt(deviceID, 10), req.Device)
+		assert.Equal(t, serviceInstallID, req.ServiceInstallID)
 		assert.Equal(t, key, req.Name)
 		assert.Equal(t, value, req.Value)
-		fmt.Fprint(w, jsonResp)
+		_, _ = fmt.Fprint(w, jsonResp)
 	})
-	expected := &DeviceServVarResponse{
+	expected := &DeviceServVarCreateResponse{
 		ID:        183330,
 		CreatedAt: "2019-09-27T17:54:21.559Z",
-		Device: odata.Object{
-			Deferred: odata.Deferred{URI: "/resin/device(1702297)"},
-			ID:       1702297,
+		ServiceInstall: odata.Object{
+			Deferred: odata.Deferred{URI: "/resin/service_install(@id)?@id=7185462"},
+			ID:       7185462,
 		},
 		Name:  "key",
 		Value: "test",
 	}
 	// When
-	actual, err := client.DeviceServVar.Create(context.Background(), DeviceID(deviceID), key, value)
+	actual, err := client.DeviceServVar.Create(context.Background(), 7185462, key, value)
 	// Then
 	assert.NilError(t, err)
 	assert.DeepEqual(t, expected, actual)
@@ -177,38 +271,30 @@ func TestDeviceServVarService_Create_UUID(t *testing.T) {
 	jsonResp := `{
 	"id": 183330,
 	"created_at": "2019-09-27T17:54:21.559Z",
-	"device": {
-		"__deferred": {
-			"uri": "/resin/device(1702297)"
-		},
-		"__id": 1702297
-	},
+    "service_install": {
+        "__id": 7185462,
+        "__deferred": {
+            "uri": "/resin/service_install(@id)?@id=7185462"
+        }
+    },
 	"name": "key",
 	"value": "test",
 	"__metadata": {
 		"uri": "/resin/device_service_environment_variable(@id)?@id=183330"
 	}
 }`
-	uuid := "1234567890123456789"
-	deviceID := int64(123456)
+	serviceInstallID := int64(7185462)
 	key := "key"
 	value := "value"
 	client, mux, cleanup := newFixture()
 	defer cleanup()
 	type request struct {
-		Device string `json:"device"`
-		Name   string `json:"name"`
-		Value  string `json:"value"`
+		ServiceInstallID int64  `json:"service_install"`
+		Name             string `json:"name"`
+		Value            string `json:"value"`
 	}
-	mux.HandleFunc("/"+deviceBasePath, func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, http.MethodGet)
-		expected := "%24filter=uuid+eq+%27" + uuid + "%27"
-		if r.URL.RawQuery != expected {
-			http.Error(w, fmt.Sprintf("query = %s ; expected %s", r.URL.RawQuery, expected), 500)
-			return
-		}
-		resp := `{"d":[{"id":123456}]}`
-		fmt.Fprint(w, resp)
+	mux.HandleFunc("/v6/service_install", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"D": [{"id": %d}]}`, serviceInstallID)
 	})
 	mux.HandleFunc("/"+deviceServVarBasePath, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
@@ -216,23 +302,23 @@ func TestDeviceServVarService_Create_UUID(t *testing.T) {
 		assert.NilError(t, err)
 		req := &request{}
 		assert.NilError(t, json.Unmarshal(b, req))
-		assert.Equal(t, strconv.FormatInt(deviceID, 10), req.Device)
+		assert.Equal(t, serviceInstallID, req.ServiceInstallID)
 		assert.Equal(t, key, req.Name)
 		assert.Equal(t, value, req.Value)
-		fmt.Fprint(w, jsonResp)
+		_, _ = fmt.Fprint(w, jsonResp)
 	})
-	expected := &DeviceServVarResponse{
+	expected := &DeviceServVarCreateResponse{
 		ID:        183330,
 		CreatedAt: "2019-09-27T17:54:21.559Z",
-		Device: odata.Object{
-			Deferred: odata.Deferred{URI: "/resin/device(1702297)"},
-			ID:       1702297,
+		ServiceInstall: odata.Object{
+			Deferred: odata.Deferred{URI: "/resin/service_install(@id)?@id=7185462"},
+			ID:       7185462,
 		},
 		Name:  "key",
 		Value: "test",
 	}
 	// When
-	actual, err := client.DeviceServVar.Create(context.Background(), DeviceUUID(uuid), key, value)
+	actual, err := client.DeviceServVar.Create(context.Background(), 7185462, key, value)
 	// Then
 	assert.NilError(t, err)
 	assert.DeepEqual(t, expected, actual)
@@ -252,7 +338,7 @@ func TestDeviceServVarService_DeleteWithName_ID_OK(t *testing.T) {
 			http.Error(w, fmt.Sprintf("query = %s ; expected %s", r.URL.RawQuery, expected), 500)
 			return
 		}
-		fmt.Fprint(w, `{
+		_, _ = fmt.Fprint(w, `{
 	"d": [
 		{
 			"id": 183330,
@@ -278,6 +364,27 @@ func TestDeviceServVarService_DeleteWithName_ID_OK(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func TestDeviceServVarService_Update(t *testing.T) {
+	// Given
+	uuid := "12345678901234567890"
+	key := "key"
+	client, mux, cleanup := newFixture()
+	defer cleanup()
+	mux.HandleFunc("/"+deviceServVarBasePath, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		expected := "%24filter=service_install/device/uuid+eq+%27" + uuid + "%27+and+name+eq+%27" + key + "%27"
+		if r.URL.RawQuery != expected {
+			http.Error(w, fmt.Sprintf("query = %s ; expected %s", r.URL.RawQuery, expected), 500)
+			return
+		}
+		_, _ = fmt.Fprint(w, "OK")
+	})
+	// When
+	err := client.DeviceServVar.Update(context.Background(), DeviceUUID(uuid), key, "newVal")
+	// Then
+	assert.NilError(t, err)
+}
+
 func TestDeviceServVarService_DeleteWithName_UUID_OK(t *testing.T) {
 	// Given
 	uuid := "12345678901234567890"
@@ -291,7 +398,7 @@ func TestDeviceServVarService_DeleteWithName_UUID_OK(t *testing.T) {
 			http.Error(w, fmt.Sprintf("query = %s ; expected %s", r.URL.RawQuery, expected), 500)
 			return
 		}
-		fmt.Fprint(w, `{
+		_, _ = fmt.Fprint(w, `{
 	"d": [
 		{
 			"id": 183330,
@@ -331,7 +438,7 @@ func TestDeviceServVarService_DeleteWithName_NotFound(t *testing.T) {
 			http.Error(w, fmt.Sprintf("query = %s ; expected %s", r.URL.RawQuery, expected), 500)
 			return
 		}
-		fmt.Fprint(w, `{
+		_, _ = fmt.Fprint(w, `{
 	"d": []
 }`)
 	})

--- a/serviceinstall.go
+++ b/serviceinstall.go
@@ -1,0 +1,77 @@
+package balena
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"go.einride.tech/balena/odata"
+)
+
+const serviceInstallBasePath = "v6/service_install"
+
+type ServiceInstallService service
+
+type InstallsService struct {
+	ID          int64        `json:"id"`
+	ServiceName string       `json:"service_name"`
+	Application odata.Object `json:"application"`
+	CreatedAt   time.Time    `json:"created_at"`
+}
+
+type ServiceInstallResponse struct {
+	InstallsService []InstallsService `json:"installs__service"`
+	ID              int64             `json:"id"`
+	CreatedAt       time.Time         `json:"created_at"`
+	Device          odata.Object      `json:"device"`
+}
+
+type ServiceInstalls []*ServiceInstallResponse
+
+// ServiceNames returns a slice of all service names contained in the ServiceInstallResponse(s).
+func (i ServiceInstalls) ServiceNames() []string {
+	names := make([]string, 0, len(i))
+	for _, install := range i {
+		for _, installsService := range install.InstallsService {
+			names = append(names, installsService.ServiceName)
+		}
+	}
+	return names
+}
+
+// FindByServiceName returns the InstallService that contains the given ServiceName.
+// Returns true if found, else false.
+func (i ServiceInstalls) FindByServiceName(serviceName string) (InstallsService, bool) {
+	for _, install := range i {
+		for _, installsService := range install.InstallsService {
+			if installsService.ServiceName == serviceName {
+				return installsService, true
+			}
+		}
+	}
+	return InstallsService{}, false
+}
+
+// List all service installs for a particular device.
+func (s *ServiceInstallService) List(ctx context.Context, deviceID IDOrUUID) (ServiceInstalls, error) {
+	query := "%24filter=device+eq+%27" + deviceID.id + "%27"
+	if deviceID.isUUID {
+		query = "%24filter=device/uuid+eq+%27" + deviceID.id + "%27"
+	}
+	query += "&%24expand=installs__service(%24select=service_name,application,created_at,id)"
+
+	type response struct {
+		D ServiceInstalls `json:"d"`
+	}
+	req, err := s.client.NewRequest(ctx, http.MethodGet, serviceInstallBasePath, query, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create request: %v", err)
+	}
+	resp := &response{}
+	err = s.client.Do(req, resp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to perform request: %v", err)
+	}
+	return resp.D, nil
+}

--- a/serviceinstall_test.go
+++ b/serviceinstall_test.go
@@ -1,0 +1,156 @@
+package balena
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"go.einride.tech/balena/odata"
+	"gotest.tools/v3/assert"
+)
+
+func TestServiceInstallService_List(t *testing.T) {
+	const actualJSON = `{
+    "d": [
+        {
+            "installs__service": [
+                {
+                    "service_name": "main",
+                    "application": {
+                        "__id": 1660000,
+                        "__deferred": {
+                            "uri": "/resin/application(@id)?@id=1660000"
+                        }
+                    },
+                    "created_at": "2020-06-18T20:26:23.470Z",
+                    "id": 500000,
+                    "__metadata": {
+                        "uri": "/resin/service(@id)?@id=500000"
+                    }
+                }
+            ],
+            "id": 7180000,
+            "created_at": "2021-10-15T08:06:13.353Z",
+            "device": {
+                "__id": 5000000,
+                "__deferred": {
+                    "uri": "/resin/device(@id)?@id=5000000"
+                }
+            },
+            "__metadata": {
+                "uri": "/resin/service_install(@id)?@id=7180000"
+            }
+        },
+        {
+            "installs__service": [
+                {
+                    "service_name": "other_service",
+                    "application": {
+                        "__id": 1790000,
+                        "__deferred": {
+                            "uri": "/resin/application(@id)?@id=1790000"
+                        }
+                    },
+                    "created_at": "2021-01-11T11:46:48.175Z",
+                    "id": 860000,
+                    "__metadata": {
+                        "uri": "/resin/service(@id)?@id=860000"
+                    }
+                }
+            ],
+            "id": 8580000,
+            "created_at": "2021-11-24T14:03:30.793Z",
+            "device": {
+                "__id": 5040000,
+                "__deferred": {
+                    "uri": "/resin/device(@id)?@id=5040000"
+                }
+            },
+            "__metadata": {
+                "uri": "/resin/service_install(@id)?@id=8580000"
+            }
+        }
+    ]
+}`
+	doTest := func(tt *testing.T, expectedQuery string, deviceID IDOrUUID) {
+		client, mux, cleanup := newFixture()
+		defer cleanup()
+		mux.HandleFunc("/"+serviceInstallBasePath, func(w http.ResponseWriter, r *http.Request) {
+			testMethod(tt, r, http.MethodGet)
+			if r.URL.RawQuery != expectedQuery {
+				tt.Errorf("query = %s ; expected %s", r.URL.RawQuery, expectedQuery)
+				http.Error(w, "query string mismatch", http.StatusInternalServerError)
+				return
+			}
+			_, _ = fmt.Fprint(w, actualJSON)
+		})
+
+		expected := ServiceInstalls{
+			{
+				InstallsService: []InstallsService{
+					{
+						ID:          500_000,
+						ServiceName: "main",
+						Application: odata.Object{
+							Deferred: odata.Deferred{
+								URI: "/resin/application(@id)?@id=1660000",
+							},
+							ID: 1660_000,
+						},
+						CreatedAt: time.Date(2020, 6, 18, 20, 26, 23, 470_000_000, time.UTC),
+					},
+				},
+				ID:        7180_000,
+				CreatedAt: time.Date(2021, 10, 15, 8, 6, 13, 353_000_000, time.UTC),
+				Device: odata.Object{
+					Deferred: odata.Deferred{
+						URI: "/resin/device(@id)?@id=5000000",
+					},
+					ID: 5000000,
+				},
+			},
+			{
+				InstallsService: []InstallsService{
+					{
+						ID:          860_000,
+						ServiceName: "other_service",
+						Application: odata.Object{
+							Deferred: odata.Deferred{
+								URI: "/resin/application(@id)?@id=1790000",
+							},
+							ID: 1790_000,
+						},
+						CreatedAt: time.Date(2021, 1, 11, 11, 46, 48, 175_000_000, time.UTC),
+					},
+				},
+				ID:        8580_000,
+				CreatedAt: time.Date(2021, 11, 24, 14, 3, 30, 793_000_000, time.UTC),
+				Device: odata.Object{
+					Deferred: odata.Deferred{
+						URI: "/resin/device(@id)?@id=5040000",
+					},
+					ID: 5040_000,
+				},
+			},
+		}
+
+		actual, err := client.ServiceInstall.List(context.Background(), deviceID)
+		assert.NilError(tt, err)
+		assert.DeepEqual(tt, actual, expected)
+	}
+
+	t.Run("device ID", func(t *testing.T) {
+		deviceID := DeviceID(5000000)
+		//nolint:lll
+		expected := "%24filter=device+eq+%275000000%27&%24expand=installs__service(%24select=service_name,application,created_at,id)"
+		doTest(t, expected, deviceID)
+	})
+	t.Run("device UUID", func(t *testing.T) {
+		deviceID := DeviceUUID("apabepa123")
+		//nolint:lll
+		expected := "%24filter=device/uuid+eq+%27apabepa123%27&%24expand=installs__service(%24select=service_name,application,created_at,id)"
+		doTest(t, expected, deviceID)
+	})
+}


### PR DESCRIPTION
This allows you to update existing environment, and service environemnt variables.

It also fixes the create function for device service environment variables, which didn't match the API upstream.

In addition to the unit tests, I have tested all methods manually in another repo.