### PR TITLE
Add device type service

### DIFF
--- a/balena.go
+++ b/balena.go
@@ -39,6 +39,7 @@ type Client struct {
 	DeviceConfVar  *DeviceConfVarService
 	DeviceTag      *DeviceTagService
 	ServiceInstall *ServiceInstallService
+	DeviceType     *DeviceTypeService
 }
 
 type service struct {
@@ -79,6 +80,7 @@ func New(httpClient *http.Client, authToken string) *Client {
 	c.DeviceTag = (*DeviceTagService)(&c.common)
 	c.ReleaseTag = (*ReleaseTagService)(&c.common)
 	c.ServiceInstall = (*ServiceInstallService)(&c.common)
+	c.DeviceType = (*DeviceTypeService)(&c.common)
 	return c
 }
 

--- a/devicetype.go
+++ b/devicetype.go
@@ -1,0 +1,72 @@
+package balena
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"go.einride.tech/balena/odata"
+)
+
+const deviceTypeBasePath = "v6/device_type"
+
+// DeviceTypeService handles communication with the device type related methods of the
+// Balena Cloud API.
+type DeviceTypeService service
+
+type DeviceTypeResponse struct {
+	ID        uint64 `json:"id"`
+	Name      string `json:"name"`
+	Slug      string `json:"slug"`
+	IsPrivate bool   `json:"is_private"`
+	// Logo will only be populated when explicitly selected through a query parameter: `$select=logo`.
+	Logo                string       `json:"logo"`
+	IsOfCPUArchitecture odata.Object `json:"is_of__cpu_architecture"`
+}
+
+// Get returns information on a single device type given its ID.
+// If the device type does not exist, both the response and error are nil.
+func (s *DeviceTypeService) Get(ctx context.Context, id int64) (*DeviceTypeResponse, error) {
+	path := odata.EntityURL(deviceTypeBasePath, strconv.FormatInt(id, 10))
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create get request: %w", err)
+	}
+	type Response struct {
+		D []DeviceTypeResponse `json:"d,omitempty"`
+	}
+	resp := &Response{}
+	err = s.client.Do(req, resp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get device type: %w", err)
+	}
+	if len(resp.D) > 1 {
+		return nil, errors.New("received more than 1 device type, expected 0 or 1")
+	}
+	if len(resp.D) == 0 {
+		return nil, nil
+	}
+	return &resp.D[0], nil
+}
+
+// GetWithQuery allows querying for device types using a custom open data protocol query.
+// The query should be a valid, escaped OData query such as `%24filter=slug+eq+'jetson-tx2'`
+//
+// Forward slash in filter keys should not be escaped (So `device_type/slug` should not be escaped).
+func (s *DeviceTypeService) GetWithQuery(ctx context.Context, query string) ([]*DeviceTypeResponse, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, deviceTypeBasePath, query, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create device type request: %w", err)
+	}
+	type Response struct {
+		D []*DeviceTypeResponse `json:"d,omitempty"`
+	}
+	resp := &Response{}
+	err = s.client.Do(req, resp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to query device type: %w", err)
+	}
+	return resp.D, nil
+}

--- a/devicetype_test.go
+++ b/devicetype_test.go
@@ -1,0 +1,119 @@
+package balena
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"go.einride.tech/balena/odata"
+	"gotest.tools/v3/assert"
+)
+
+const (
+	deviceTypeResponse = `{
+	"d": [
+	  {
+		"id": 34,
+		"slug": "jetson-tx2",
+		"name": "Nvidia Jetson TX2",
+		"is_private": false,
+		"is_of__cpu_architecture": {
+		  "__id": 1,
+		  "__deferred": {
+			"uri": "/resin/cpu_architecture(@id)?@id=1"
+		  }
+		},
+		"belongs_to__device_family": null,
+		"__metadata": {
+		  "uri": "/resin/device_type(@id)?@id=34"
+		}
+	  }
+	  ]
+	}`
+)
+
+func TestDeviceTypeService_Get(t *testing.T) {
+	// Given
+	client, mux, cleanup := newFixture()
+	defer cleanup()
+	entityID := int64(34)
+	mux.HandleFunc(
+		"/"+odata.EntityURL(deviceTypeBasePath, strconv.FormatInt(entityID, 10)),
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodGet)
+			fmt.Fprint(w, deviceTypeResponse)
+		},
+	)
+	expected := &DeviceTypeResponse{
+		ID:        34,
+		Name:      "Nvidia Jetson TX2",
+		Slug:      "jetson-tx2",
+		IsPrivate: false,
+		IsOfCPUArchitecture: odata.Object{
+			ID: 1,
+			Deferred: odata.Deferred{
+				URI: "/resin/cpu_architecture(@id)?@id=1",
+			},
+		},
+	}
+	// When
+	actual, err := client.DeviceType.Get(context.Background(), entityID)
+	// Then
+	assert.NilError(t, err)
+	assert.DeepEqual(t, expected, actual)
+}
+
+func TestDeviceTypeService_Get_NotFound(t *testing.T) {
+	// Given
+	client, mux, cleanup := newFixture()
+	defer cleanup()
+	entityID := int64(34)
+	mux.HandleFunc(
+		"/"+odata.EntityURL(deviceTypeBasePath, strconv.FormatInt(entityID, 10)),
+		func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodGet)
+			fmt.Fprint(w, `{"d":[]}`)
+		},
+	)
+	// When
+	device, err := client.DeviceType.Get(context.Background(), entityID)
+	// Then
+	assert.NilError(t, err)
+	assert.Assert(t, device == nil)
+}
+
+func TestDeviceTypeService_GetWithQuery(t *testing.T) {
+	// Given
+	client, mux, cleanup := newFixture()
+	defer cleanup()
+	mux.HandleFunc("/"+deviceTypeBasePath, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		expected := "%24filter=key+eq+%27value%27"
+		if r.URL.RawQuery != expected {
+			http.Error(w, fmt.Sprintf("query = %s ; expected %s", r.URL.RawQuery, expected), http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprint(w, deviceTypeResponse)
+	})
+	expected := []*DeviceTypeResponse{
+		{
+			ID:        34,
+			Name:      "Nvidia Jetson TX2",
+			Slug:      "jetson-tx2",
+			IsPrivate: false,
+			IsOfCPUArchitecture: odata.Object{
+				ID: 1,
+				Deferred: odata.Deferred{
+					URI: "/resin/cpu_architecture(@id)?@id=1",
+				},
+			},
+		},
+	}
+	// When
+	actual, err := client.DeviceType.GetWithQuery(context.Background(), "%24filter=key+eq+%27value%27")
+	// Then
+	assert.NilError(t, err)
+	assert.DeepEqual(t, expected, actual)
+}


### PR DESCRIPTION
This pull request adds a service that can be used to query for specific device types. The service allows the user to query for a device type with a particular ID (`Get`) or craft a query manually to retrieve specific information (`GetWithQuery`).